### PR TITLE
Store GIF posts by embed URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1078,6 +1078,8 @@
         {{if imageOrientation ==="portrait"}} object-contain size-full {{else}} w-full h-full object-cover{{/if}}
         {{/if}} 
         {{if !~inModal && imageOrientation ==="portrait"}} object-contain size-full {{else !~inModal && imageOrientation !="portrait"}} w-full h-full object-cover{{/if}}"  alt="preview" />
+        {{else fileType === "Gif"}}
+        <iframe src="{{:fileContent}}" width="100%" height="300" frameborder="0" allowfullscreen></iframe>
         {{else fileType === "Audio"}}
         <audio class="js-player" controls>
             <source src="{{:fileContent}}" type="audio/mpeg" />
@@ -1112,6 +1114,8 @@
         {{if depth > 0 && fileContentComment}}
         {{if fileType === "Image"}}
         <img src="{{:fileContentComment}}" style="width:211px;height:138px;object-fit:contain;" alt="preview" />
+        {{else fileType === "Gif"}}
+        <iframe src="{{:fileContentComment}}" width="211" height="138" frameborder="0" allowfullscreen></iframe>
         {{else fileType === "Audio"}}
         <label for="audio-player">{{:fileContentCommentName}}</label>
         <audio class="js-player" controls>
@@ -1286,6 +1290,8 @@
                       {{if depth > 0 && fileContentComment}}
                   {{if fileType === "Image"}}
                     <img src="{{:fileContentComment}}" style="width:211px;height:138px;object-fit:contain;" alt="preview" />
+                  {{else fileType === "Gif"}}
+                    <iframe src="{{:fileContentComment}}" width="211" height="138" frameborder="0" allowfullscreen></iframe>
                   {{else fileType === "Audio"}}
                   <label for="audio-player " class="max-[702px]:line-clamp-1">{{:fileContentCommentName}}</label>
                     <audio class="js-player" controls>

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -184,6 +184,8 @@
                   {{if imageOrientation ==="portrait"}} object-contain size-full {{else}} w-full h-full object-cover{{/if}}
                   {{/if}} 
                   {{if !~inModal && imageOrientation ==="portrait"}} object-contain size-full {{else !~inModal && imageOrientation !="portrait"}} w-full h-full object-cover{{/if}}"  alt="preview" />
+                  {{else fileType === "Gif"}}
+                  <iframe src="{{:fileContent}}" width="100%" height="300" frameborder="0" allowfullscreen></iframe>
                   {{else fileType === "Audio"}}
                   <audio class="js-player" controls>
                       <source src="{{:fileContent}}" type="audio/mpeg" />
@@ -218,6 +220,8 @@
                   {{if depth > 0 && fileContentComment}}
                   {{if fileType === "Image"}}
                   <img src="{{:fileContentComment}}" style="width:211px;height:138px;object-fit:contain;" alt="preview" />
+                  {{else fileType === "Gif"}}
+                  <iframe src="{{:fileContentComment}}" width="211" height="138" frameborder="0" allowfullscreen></iframe>
                   {{else fileType === "Audio"}}
                   <label for="audio-player">{{:fileContentCommentName}}</label>
                   <audio class="js-player" controls>
@@ -391,6 +395,8 @@
                                 {{if depth > 0 && fileContentComment}}
                             {{if fileType === "Image"}}
                               <img src="{{:fileContentComment}}" style="width:211px;height:138px;object-fit:contain;" alt="preview" />
+                            {{else fileType === "Gif"}}
+                              <iframe src="{{:fileContentComment}}" width="211" height="138" frameborder="0" allowfullscreen></iframe>
                             {{else fileType === "Audio"}}
                             <label for="audio-player " class="max-[702px]:line-clamp-1">{{:fileContentCommentName}}</label>
                               <audio class="js-player" controls>

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -10,9 +10,11 @@ import { GLOBAL_PAGE_TAG } from "../../tag.js";
 import { findNode, buildTree, mapItem } from "../../ui/render.js";
 import {
   pendingFile,
+  pendingGifUrl,
   fileTypeCheck,
   setPendingFile,
   setFileTypeCheck,
+  setPendingGifUrl,
 } from "../uploads/handlers.js";
 // import { processFileFields } from "../../utils/handleFile.js";
 import { uploadAndGetFileLink } from "../../utils/upload.js";
@@ -65,7 +67,7 @@ export async function createFeedToSubmit(
   const inModal = Boolean(formWrapper?.closest('#modalFeedRoot'));
   const editor = $(`.${formElementId} .editor`);
   const htmlContent = editor.html().trim();
-  if (!htmlContent && !pendingFile) {
+  if (!htmlContent && !pendingFile && !pendingGifUrl) {
     alert("Please enter some content or upload a file.");
     return null;
   }
@@ -159,6 +161,9 @@ export async function createFeedToSubmit(
     if (fileTypeCheck === "Image") {
       finalPayload.image_orientation = await getImageOrientation(pendingFile);
     }
+  } else if (pendingGifUrl) {
+    finalPayload.file_link = pendingGifUrl;
+    finalPayload.file_type = "Gif";
   }
 
   try {
@@ -252,6 +257,7 @@ export async function createFeedToSubmit(
     editor.html("");
     setPendingFile(null);
     setFileTypeCheck("");
+    setPendingGifUrl(null);
     $("#file-input").val("");
   } catch (err) {
    

--- a/src/features/posts/preview.js
+++ b/src/features/posts/preview.js
@@ -28,7 +28,7 @@ if (previewModal) {
 
 $(document).on(
   'click',
-  '.file-preview img',
+  '.file-preview img, .file-preview iframe, .file-preview video, .file-preview audio, .file-preview a',
   function (e) {
     e.preventDefault();
     if (!previewModal) return;

--- a/src/features/uploads/handlers.js
+++ b/src/features/uploads/handlers.js
@@ -1,5 +1,6 @@
 export let pendingFile = null;
 export let fileTypeCheck = "";
+export let pendingGifUrl = null;
 
 export function setPendingFile(file) {
   pendingFile = file;
@@ -8,8 +9,13 @@ export function setPendingFile(file) {
 export function setFileTypeCheck(type) {
   fileTypeCheck = type;
 }
+
+export function setPendingGifUrl(url) {
+  pendingGifUrl = url;
+}
 $(document).on("change", ".file-input, #file-input", function (e) {
   pendingFile = e.target.files[0] || null;
+  pendingGifUrl = null;
   if (pendingFile) {
     const type = pendingFile.type;
     if (type.startsWith("audio/")) {

--- a/src/ui/gif.js
+++ b/src/ui/gif.js
@@ -1,3 +1,5 @@
+import { setPendingGifUrl, setPendingFile, setFileTypeCheck } from '../features/uploads/handlers.js';
+
 export function initGifPicker() {
   const modal = $(
     `<div id="gif-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex justify-center items-start pt-12 !z-[2147483649]">
@@ -73,10 +75,12 @@ export function initGifPicker() {
       $('#gif-grid').empty();
       (data.data || []).forEach(g => {
         const originalUrl = g.images.original.url;
+        const embed = g.embed_url;
         const filename = originalUrl.split('/').pop().split('?')[0];
         $('<img>')
           .attr('src', g.images.fixed_height_small.url)
           .attr('data-full', originalUrl)
+          .attr('data-embed', embed)
           .attr('data-filename', filename)
           .addClass('cursor-pointer rounded')
           .appendTo('#gif-grid');
@@ -151,6 +155,7 @@ export function initGifPicker() {
 
   $('#gif-grid').on('click', 'img', async function () {
     const url = $(this).data('full');
+    const embed = $(this).data('embed');
     const filename = $(this).data('filename') || 'giphy.gif';
     if (pondInstance) {
       try {
@@ -159,6 +164,9 @@ export function initGifPicker() {
         if (blob.type === 'image/gif') {
           const file = new File([blob], filename, { type: blob.type });
           await pondInstance.addFile(file);
+          setPendingFile(null);
+          setPendingGifUrl(embed);
+          setFileTypeCheck('Gif');
         } else {
 
         }

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -90,7 +90,7 @@ export function mapItem(raw, depth = 0, isDisabled = false) {
     (b) => b.Bookmarking_Contact?.id === GLOBAL_AUTHOR_ID
   );
 
-  const linkData = raw.file_content;
+  const linkData = raw.file_content || raw.file_link;
   const parsed =  parseFileField(linkData);
   const fileContent = parsed.link || "";
   const fileName = raw.file_name || parsed.name || "";

--- a/src/utils/filePond.js
+++ b/src/utils/filePond.js
@@ -1,4 +1,4 @@
-import { setPendingFile, setFileTypeCheck } from '../features/uploads/handlers.js';
+import { setPendingFile, setFileTypeCheck, setPendingGifUrl } from '../features/uploads/handlers.js';
 import { micIcon } from '../ui/emoji.js';
 FilePond.registerPlugin(
   FilePondPluginFileValidateType,
@@ -113,6 +113,7 @@ export function initFilePond() {
     pond.on("removefile", () => {
       setPendingFile(null);
       setFileTypeCheck("");
+      setPendingGifUrl(null);
       inputElement.value = "";
       canvas.style.display = "none";
       const cancelBtn = section.querySelector(".cancelRecordingBtn");


### PR DESCRIPTION
## Summary
- track pending gif URL in upload handlers
- allow selecting GIFs without uploading files
- parse file link when rendering posts
- embed GIFs via `<iframe>` for posts and comments
- support previewing iframes and reset state on file removal

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6888773346908321b2f81185a62897ce