### PR TITLE
Fix GIF preview handling

### DIFF
--- a/src/features/uploads/handlers.js
+++ b/src/features/uploads/handlers.js
@@ -1,6 +1,7 @@
 export let pendingFile = null;
 export let fileTypeCheck = "";
 export let pendingGifUrl = null;
+let ignoreNextChange = false;
 
 export function setPendingFile(file) {
   pendingFile = file;
@@ -12,6 +13,10 @@ export function setFileTypeCheck(type) {
 
 export function setPendingGifUrl(url) {
   pendingGifUrl = url;
+}
+
+export function setIgnoreNextChange(val) {
+  ignoreNextChange = val;
 }
 $(document).on("change", ".file-input, #file-input", function (e) {
   if (ignoreNextChange) {

--- a/src/ui/gif.js
+++ b/src/ui/gif.js
@@ -1,4 +1,9 @@
-import { setPendingGifUrl, setPendingFile, setFileTypeCheck } from '../features/uploads/handlers.js';
+import {
+  setPendingGifUrl,
+  setPendingFile,
+  setFileTypeCheck,
+  setIgnoreNextChange,
+} from '../features/uploads/handlers.js';
 
 export function initGifPicker() {
   const modal = $(


### PR DESCRIPTION
## Summary
- handle ignoreNextChange flag for GIF uploads
- import setter in the GIF UI code to avoid reference error

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6888846d6bd8832188a65bbe46a1e856